### PR TITLE
DataLoader and IDocumentExecutionListener support

### DIFF
--- a/GraphQl.AspNetCore/GraphQl.AspNetCore.csproj
+++ b/GraphQl.AspNetCore/GraphQl.AspNetCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Jürgen Gutsch</Authors>
@@ -16,9 +15,8 @@
     <AssemblyVersion>1.1.4.0</AssemblyVersion>
     <FileVersion>1.1.4.0</FileVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-802" />
+    <PackageReference Include="GraphQL" Version="2.0.0-alpha-868" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />

--- a/GraphQl.AspNetCore/GraphQlBuilder.cs
+++ b/GraphQl.AspNetCore/GraphQlBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using GraphQL.DataLoader;
+using GraphQL.Execution;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GraphQl.AspNetCore
@@ -22,6 +24,20 @@ namespace GraphQl.AspNetCore
 
             _services.AddSingleton<ISchemaProvider>(schema);
 
+            return this;
+        }
+        
+        public IGraphQlBuilder AddDocumentExecutionListener<T>()
+            where T: class, IDocumentExecutionListener
+        {
+            _services.AddSingleton<IDocumentExecutionListener, T>();
+            return this;
+        }
+        
+        public IGraphQlBuilder AddDataLoader()
+        {
+            _services.AddSingleton<IDataLoaderContextAccessor, DataLoaderContextAccessor>();
+            AddDocumentExecutionListener<DataLoaderDocumentListener>();
             return this;
         }
 

--- a/GraphQl.AspNetCore/GraphQlMiddleware.cs
+++ b/GraphQl.AspNetCore/GraphQlMiddleware.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using GraphQL;
+using GraphQL.Execution;
 using GraphQL.Http;
 using GraphQL.Types;
 using Microsoft.AspNetCore.Authentication;
@@ -20,17 +23,20 @@ namespace GraphQl.AspNetCore
         private readonly ISchemaProvider _schemaProvider;
         private readonly GraphQlMiddlewareOptions _options;
         private readonly DocumentExecuter _executer;
+        private readonly IEnumerable<IDocumentExecutionListener> _executionListeners;
 
         public GraphQlMiddleware(
             RequestDelegate next,
             ISchemaProvider schemaProvider,
             GraphQlMiddlewareOptions options,
-            DocumentExecuter executer)
+            DocumentExecuter executer,
+            IEnumerable<IDocumentExecutionListener> executionListeners)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _schemaProvider = schemaProvider ?? throw new ArgumentNullException(nameof(schemaProvider));
             _options = options ?? throw new ArgumentNullException(nameof(options));
-            _executer = executer;
+            _executer = executer ?? throw new ArgumentNullException(nameof(options));;
+            _executionListeners = executionListeners ?? new IDocumentExecutionListener[0];
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -76,6 +82,7 @@ namespace GraphQl.AspNetCore
                 options.ComplexityConfiguration = _options.ComplexityConfiguration;
                 options.UserContext = httpContext;
                 options.ExposeExceptions = _options.ExposeExceptions;
+                ConfigureDocumentExecutionListeners(options, _executionListeners);
             });
 
             if (result.Errors?.Count > 0)
@@ -134,6 +141,20 @@ namespace GraphQl.AspNetCore
             parameters.Query = query ?? parameters.Query;
 
             return parameters;
+        }
+        
+        private static void ConfigureDocumentExecutionListeners(ExecutionOptions options, IEnumerable<IDocumentExecutionListener> listeners)
+        {
+            Debug.Assert(listeners != null, "listeners != null");
+
+            var listenerSet = new HashSet<IDocumentExecutionListener>(options.Listeners);           
+            listenerSet.UnionWith(listeners);
+            
+            options.Listeners.Clear();
+            foreach (var listener in listenerSet)
+            {
+                options.Listeners.Add(listener);
+            }
         }
     }
 }

--- a/GraphQl.AspNetCore/GraphQlMiddleware.cs
+++ b/GraphQl.AspNetCore/GraphQlMiddleware.cs
@@ -19,15 +19,18 @@ namespace GraphQl.AspNetCore
         private readonly RequestDelegate _next;
         private readonly ISchemaProvider _schemaProvider;
         private readonly GraphQlMiddlewareOptions _options;
+        private readonly DocumentExecuter _executer;
 
         public GraphQlMiddleware(
             RequestDelegate next,
             ISchemaProvider schemaProvider,
-            GraphQlMiddlewareOptions options)
+            GraphQlMiddlewareOptions options,
+            DocumentExecuter executer)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));
             _schemaProvider = schemaProvider ?? throw new ArgumentNullException(nameof(schemaProvider));
             _options = options ?? throw new ArgumentNullException(nameof(options));
+            _executer = executer;
         }
 
         public async Task Invoke(HttpContext httpContext)
@@ -63,9 +66,7 @@ namespace GraphQl.AspNetCore
 
             ISchema schema = _schemaProvider.Create(httpContext.RequestServices);
 
-            var executer = new DocumentExecuter();
-
-            var result = await executer.ExecuteAsync(options =>
+            var result = await _executer.ExecuteAsync(options =>
             {
                 options.Schema = schema;
                 options.Query = parameters.Query;

--- a/GraphQl.AspNetCore/IGraphQlBuilder.cs
+++ b/GraphQl.AspNetCore/IGraphQlBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using GraphQL.Execution;
 
 namespace GraphQl.AspNetCore
 {
@@ -12,6 +13,20 @@ namespace GraphQl.AspNetCore
         /// <returns></returns>
         IGraphQlBuilder AddSchema(string name, Action<SchemaConfiguration> configure);
 
+        /// <summary>
+        /// Adds a <see cref="IDocumentExecutionListener"/>.
+        /// </summary>
+        /// <typeparam name="T">The listener to add.</typeparam>
+        /// <returns></returns>
+        IGraphQlBuilder AddDocumentExecutionListener<T>()
+            where T : class, IDocumentExecutionListener;
+
+        /// <summary>
+        /// Adds Data Loader support.
+        /// </summary>
+        /// <returns></returns>
+        IGraphQlBuilder AddDataLoader();
+        
         IGraphQlBuilder AddGraphTypes();
     }
 }

--- a/GraphQl.AspNetCore/ServiceCollectionExtensions.cs
+++ b/GraphQl.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using GraphQl.AspNetCore;
 using GraphQL;
+using GraphQL.DataLoader;
+using GraphQL.Execution;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -28,6 +30,31 @@ namespace Microsoft.Extensions.DependencyInjection
             configure(schema);
 
             return builder.AddSchema(schema);
+        }
+
+        /// <summary>
+        /// Adds a GraphQL <see cref="IDocumentExecutionListener"/> services to the specified <see cref="IServiceCollection">IServiceCollection</see>.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <typeparam name="T">The listener to add.</typeparam>
+        /// <returns></returns>
+        public static IServiceCollection AddDocumentExecutionListener<T>(this IServiceCollection services)
+            where T: class, IDocumentExecutionListener
+        {
+            services.AddSingleton<IDocumentExecutionListener, T>();
+            return services;
+        }
+        
+        /// <summary>
+        /// Add GraphQL DataLoader services to the specified <see cref="IServiceCollection">IServiceCollection</see>.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <returns></returns>
+        public static IServiceCollection AddDataLoader(this IServiceCollection services)
+        {
+            services.AddSingleton<IDataLoaderContextAccessor, DataLoaderContextAccessor>();
+            services.AddDocumentExecutionListener<DataLoaderDocumentListener>();
+            return services;
         }
     }
 }

--- a/GraphQl.AspNetCore/ServiceCollectionExtensions.cs
+++ b/GraphQl.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GraphQl.AspNetCore;
+using GraphQL;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -19,6 +20,8 @@ namespace Microsoft.Extensions.DependencyInjection
             if (configure == null)
                 throw new ArgumentNullException(nameof(configure));
 
+            services.AddScoped<DocumentExecuter>();
+            
             var builder = new GraphQlBuilder(services);
 
             var schema = new SchemaConfiguration(null);

--- a/GraphQlDemo.Query/GraphQlDemo.Query.csproj
+++ b/GraphQlDemo.Query/GraphQlDemo.Query.csproj
@@ -1,10 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-802" />
+    <PackageReference Include="GraphQL" Version="2.0.0-alpha-868" />
   </ItemGroup>
 </Project>

--- a/GraphQlDemo/GraphQlDemo.csproj
+++ b/GraphQlDemo/GraphQlDemo.csproj
@@ -1,15 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GenFu" Version="1.4.1" />
-    <PackageReference Include="GraphQL" Version="2.0.0-alpha-802" />
+    <PackageReference Include="GraphQL" Version="2.0.0-alpha-868" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
@@ -20,5 +18,4 @@
     <ProjectReference Include="..\GraphQl.AspNetCore\GraphQl.AspNetCore.csproj" />
     <ProjectReference Include="..\GraphQlDemo.Query\GraphQlDemo.Query.csproj" />
   </ItemGroup>
-
 </Project>

--- a/GraphQlDemo/Startup.cs
+++ b/GraphQlDemo/Startup.cs
@@ -38,9 +38,10 @@ namespace GraphQlDemo
             });
 
             services.AddGraphQl(schema =>
-            {
-                schema.SetQueryType<BooksQuery>();
-            });
+                {
+                    schema.SetQueryType<BooksQuery>();
+                });
+                // .AddDataLoader();
 
             // All graph types must be registered
             services.AddSingleton<BooksQuery>();


### PR DESCRIPTION
Hey there. I noticed [DataLoader](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/docs/src/dataloader.md) support is not there (yet), so I added it.

In essence, `.AddDataLoader()` can be called on the `IGraphQlBuilder`, e.g.

```csharp
services.AddGraphQl(schema => { schema.SetQueryType<BooksQuery>(); })
        .AddDataLoader();
```

This will add the `DataLoaderDocumentListener` to the services. Custom execution listeners can be added via the new `.AddDocumentExecutionListener()` method. All registered `IDocumentExecutionListener` instances are then injected into the middleware and set on the `DocumentExecutor` in the middleware.

I did refactor the `DocumentExecutor` to be injected to the middleware as well. This way an earlier middleware would have the chance to configure fields not covered by the options.