### PR TITLE
Fix IoC container scope issue

### DIFF
--- a/GraphQl.AspNetCore/GraphQlMiddleware.cs
+++ b/GraphQl.AspNetCore/GraphQlMiddleware.cs
@@ -20,16 +20,20 @@ namespace GraphQl.AspNetCore
     public class GraphQlMiddleware
     {
         private readonly RequestDelegate _next;
+
         private readonly ISchemaProvider _schemaProvider;
+
         private readonly GraphQlMiddlewareOptions _options;
-        private readonly DocumentExecuter _executer;
+
+        private readonly IDocumentExecuter _executer;
+
         private readonly IEnumerable<IDocumentExecutionListener> _executionListeners;
 
         public GraphQlMiddleware(
             RequestDelegate next,
             ISchemaProvider schemaProvider,
             GraphQlMiddlewareOptions options,
-            DocumentExecuter executer,
+            IDocumentExecuter executer,
             IEnumerable<IDocumentExecutionListener> executionListeners)
         {
             _next = next ?? throw new ArgumentNullException(nameof(next));

--- a/GraphQl.AspNetCore/ServiceCollectionExtensions.cs
+++ b/GraphQl.AspNetCore/ServiceCollectionExtensions.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services"></param>
         /// <param name="configure">Action to configure the default schema.</param>
         /// <returns></returns>
-        public static IGraphQlBuilder AddGraphQl(this IServiceCollection services, Action<SchemaConfiguration> configure)
+        public static IGraphQlBuilder AddGraphQl(this IServiceCollection services,
+            Action<SchemaConfiguration> configure)
         {
             if (services == null)
                 throw new ArgumentNullException(nameof(services));
@@ -22,8 +23,8 @@ namespace Microsoft.Extensions.DependencyInjection
             if (configure == null)
                 throw new ArgumentNullException(nameof(configure));
 
-            services.AddScoped<DocumentExecuter>();
-            
+            services.AddSingleton<IDocumentExecuter, DocumentExecuter>();
+
             var builder = new GraphQlBuilder(services);
 
             var schema = new SchemaConfiguration(null);
@@ -39,12 +40,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="T">The listener to add.</typeparam>
         /// <returns></returns>
         public static IServiceCollection AddDocumentExecutionListener<T>(this IServiceCollection services)
-            where T: class, IDocumentExecutionListener
+            where T : class, IDocumentExecutionListener
         {
             services.AddSingleton<IDocumentExecutionListener, T>();
             return services;
         }
-        
+
         /// <summary>
         /// Add GraphQL DataLoader services to the specified <see cref="IServiceCollection">IServiceCollection</see>.
         /// </summary>


### PR DESCRIPTION
IoC container was not able to resolve `DocumentExecuter` from scope. I added that as singleton.

I assume when `app.UseGraphql()` is called, no scope is created and that's the reason for current middleware failing on startup.