### PR TITLE
Simplify package usage

### DIFF
--- a/GraphQl.AspNetCore/ApplicationBuilderExtensions.cs
+++ b/GraphQl.AspNetCore/ApplicationBuilderExtensions.cs
@@ -9,13 +9,26 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public static class ApplicationBuilderExtensions
     {
+        private static readonly PathString defaultPath = "/graphql";
+
+        /// <summary>
+        /// Adds a GraphQL middleware to the <see cref="IApplicationBuilder"/> request execution pipeline with default path and options.
+        /// </summary>
+        /// <param name="builder">The builder.</param>
+        /// <returns></returns>
+        public static IApplicationBuilder UseGraphQl(this IApplicationBuilder builder)
+        {
+            return builder.UseGraphQl(null, new GraphQlMiddlewareOptions());
+        }
+
         /// <summary>
         /// Adds a GraphQL middleware to the <see cref="IApplicationBuilder"/> request execution pipeline with default options.
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="path"></param>
         /// <returns></returns>
-        public static IApplicationBuilder UseGraphQl(this IApplicationBuilder builder,
+        public static IApplicationBuilder UseGraphQl(
+            this IApplicationBuilder builder,
             PathString path)
         {
             return builder.UseGraphQl(path, new GraphQlMiddlewareOptions());
@@ -28,8 +41,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="path"></param>
         /// <param name="configure"></param>
         /// <returns></returns>
-        public static IApplicationBuilder UseGraphQl(this IApplicationBuilder builder,
-            PathString path, Action<GraphQlMiddlewareOptions> configure)
+        public static IApplicationBuilder UseGraphQl(
+            this IApplicationBuilder builder,
+            PathString path,
+            Action<GraphQlMiddlewareOptions> configure)
         {
             var options = new GraphQlMiddlewareOptions();
             configure(options);
@@ -44,14 +59,19 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="path"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        public static IApplicationBuilder UseGraphQl(this IApplicationBuilder builder,
-            PathString path, GraphQlMiddlewareOptions options)
+        public static IApplicationBuilder UseGraphQl(
+            this IApplicationBuilder builder,
+            PathString path,
+            GraphQlMiddlewareOptions options)
         {
             if (builder == null)
                 throw new ArgumentNullException(nameof(builder));
 
             if (options == null)
                 throw new ArgumentNullException(nameof(options));
+
+            if (path == null)
+                path = defaultPath;
 
             var schemaProvider = SchemaConfiguration.GetSchemaProvider(options.SchemaName, builder.ApplicationServices);
 

--- a/GraphQlDemo/Startup.cs
+++ b/GraphQlDemo/Startup.cs
@@ -69,6 +69,9 @@ namespace GraphQlDemo
             app.UseHttpsRedirection();
             app.UseStaticFiles();
 
+            // the simplest form to use GraphQL. defaults to /graphql with default options
+            // app.UseGraphQl();
+
             app.UseGraphQl("/graphql", options =>
             {
                 //options.SchemaName = "SecondSchema"; // optional if only one schema is registered

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ The `GraphQlMiddlewareOptions` are pretty simple.
 * FormatOutput: This property defines whether the output is prettified and indented for debugging purposes. The default is set to `true`.
 * ComplexityConfiguration: This property is used to customize the complexity configuration.
 * ExposeExceptions: This property controls whether exception details such as stack traces should be returned to clients. This defaults to `false` and should only be set to `true` in the Development environment.
-* EnableMetrics: Enable metrics defaults to `false`. See [GraphQL .net client documentation](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/docs/src/learn.md#metrics) how to create a stats report
 
 This should be enough for the first time. If needed it is possible to expose the Newtonsoft.JSON settings, which are used in GraphQL library later on.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The `GraphQlMiddlewareOptions` are pretty simple.
 * FormatOutput: This property defines whether the output is prettified and indented for debugging purposes. The default is set to `true`.
 * ComplexityConfiguration: This property is used to customize the complexity configuration.
 * ExposeExceptions: This property controls whether exception details such as stack traces should be returned to clients. This defaults to `false` and should only be set to `true` in the Development environment.
+* EnableMetrics: Enable metrics defaults to `false`. See [GraphQL .net client documentation](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/docs/src/learn.md#metrics) how to create a stats report.
 
 This should be enough for the first time. If needed it is possible to expose the Newtonsoft.JSON settings, which are used in GraphQL library later on.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The `GraphQlMiddlewareOptions` are pretty simple.
 * FormatOutput: This property defines whether the output is prettified and indented for debugging purposes. The default is set to `true`.
 * ComplexityConfiguration: This property is used to customize the complexity configuration.
 * ExposeExceptions: This property controls whether exception details such as stack traces should be returned to clients. This defaults to `false` and should only be set to `true` in the Development environment.
+* EnableMetrics: Enable metrics defaults to `false`. See [GraphQL .net client documentation](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/docs/src/learn.md#metrics) how to create a stats report.
 
 This should be enough for the first time. If needed it is possible to expose the Newtonsoft.JSON settings, which are used in GraphQL library later on.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ The `GraphQlMiddlewareOptions` are pretty simple.
 * FormatOutput: This property defines whether the output is prettified and indented for debugging purposes. The default is set to `true`.
 * ComplexityConfiguration: This property is used to customize the complexity configuration.
 * ExposeExceptions: This property controls whether exception details such as stack traces should be returned to clients. This defaults to `false` and should only be set to `true` in the Development environment.
-* EnableMetrics: Enable metrics defaults to `false`. See [GraphQL .net client documentation](https://github.com/graphql-dotnet/graphql-dotnet/blob/master/docs/src/learn.md#metrics) how to create a stats report.
 
 This should be enough for the first time. If needed it is possible to expose the Newtonsoft.JSON settings, which are used in GraphQL library later on.
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,26 @@ services.AddSingleton<PublisherType>();
 
 In the `Configure` method, you add the GraphQL middleware like this:
 
-You can use two different ways to register the GraphQlMiddleware:
+You can use different ways to register the GraphQlMiddleware:
 
 ```csharp
+// the simplest form to use GraphQl. defaults to '/graphql' with default options
+app.UseGraphQl();
+
+// or specify options only (default path)
+app.UseGraphQl(new GraphQlMiddlewareOptions
+{
+    FormatOutput = true, // default
+    ComplexityConfiguration = new ComplexityConfiguration()); //default
+});
+
+app.UseGraphQl(options =>
+{
+    options.EnableMetrics = true;
+});
+
+// or specify path and options
+
 app.UseGraphQl("/graphql", new GraphQlMiddlewareOptions
 {
     FormatOutput = true, // default


### PR DESCRIPTION
This pull request is based on the opinion that users should get going without too much configuration. Why bother users with setting the path while the specification dictates that the default is '/graphql'.

I therefore created overloads so the bare minimum to get going with the package is this:

```
// Configure
app.UseGraphQl();

// ConfigureServices
services.AddGraphQl(opts =>
{
     opts.SetQueryType<RootQuery>();
});
```

Because this is opinion based I only changed the _graphql_ application builder and didn't touch the _graphiql_ implementation.

If this is not in line with your own ideas about the package feel free to decline.