### PR TITLE
Using dbcontext as source for graphql data types

### DIFF
--- a/GraphQL.AspNetCore.Data/GraphBuilder.cs
+++ b/GraphQL.AspNetCore.Data/GraphBuilder.cs
@@ -1,25 +1,56 @@
 ﻿
+using GraphQL.Builders;
+using GraphQL.Types;
+using Microsoft.EntityFrameworkCore.Metadata;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace GraphQL.AspNetCore.Data
 {
     public class GraphBuilder
     {
-        public GraphQLTypeBuilder<T> Entity<T>()
-        {
-            throw new NotImplementedException();
-        }
-    }
+        private List<IBuildGraphQLType> _graphBuilders;
+        private IModel _model;
 
-    public class GraphQLTypeBuilder<T>
-    {
+        public GraphBuilder()
+        {
+            _graphBuilders = new List<IBuildGraphQLType>();
+        }
+
+
+        public GraphBuilder(IModel model = null) : this()
+        {
+            _model = model;
+        }
+
+     
+        public GraphBuilder Define<T>(Action<GraphQLTypeBuilder<T>> configure = null)
+        {
+           var builder = GraphQLTypeBuilder.CreateFor<T>();
+            _graphBuilders.Add(builder);
+
+            if (_model != null)
+            {
+                builder.FieldsFrom(_model);
+            }
+            configure?.Invoke(builder);
+            return this;
+        }
+
+        public IReadOnlyCollection<IGraphType> BuildGraphTypes()
+        {
+            return _graphBuilders.Select(b => b.Build()).ToArray();
+        }
+
+
     }
 
     public static class GraphQLTypeBuilderExtensions
     {
         public static GraphQLTypeBuilder<T> AsRootType<T>(
-            this GraphQLTypeBuilder<T> builder, 
+            this GraphQLTypeBuilder<T> builder,
             string name)
         {
             throw new NotImplementedException();

--- a/GraphQL.AspNetCore.Data/GraphQLTypeBuilder.cs
+++ b/GraphQL.AspNetCore.Data/GraphQLTypeBuilder.cs
@@ -1,0 +1,13 @@
+﻿namespace GraphQL.AspNetCore.Data
+{
+    public static class GraphQLTypeBuilder
+    {
+
+        public static GraphQLTypeBuilder<T> CreateFor<T>()
+        {
+            return new GraphQLTypeBuilder<T>();
+        }
+
+
+    }
+}

--- a/GraphQL.AspNetCore.Data/GraphQLTypeBuilder1.cs
+++ b/GraphQL.AspNetCore.Data/GraphQLTypeBuilder1.cs
@@ -1,0 +1,90 @@
+﻿using GraphQL.Types;
+using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace GraphQL.AspNetCore.Data
+{
+    public class GraphQLTypeBuilder<T> : IBuildGraphQLType
+    {
+        private Dictionary<string, EventStreamFieldType> _fields = new Dictionary<string, EventStreamFieldType>();
+
+        public GraphQLTypeBuilder<T> FieldsFrom(IModel model)
+        {
+            var entityType = model.GetEntityTypes().SingleOrDefault(et => et.ClrType == typeof(T));
+
+            if (entityType != null)
+            {
+                foreach (var item in entityType.GetProperties())
+                {
+                    GetOrCreate(item.Name);
+                }
+            }
+            return this;
+        }
+
+        public GraphQLTypeBuilder<T> Field<TV>(Expression<Func<T, TV>> expression, Action<FieldBuilder> configure)
+        {
+            var field = GetOrCreate(expression.NameOf());
+            var fieldBuilder = new FieldBuilder(field);
+            configure(fieldBuilder);
+            return this;
+        }
+
+        IGraphType IBuildGraphQLType.Build()
+        {
+            return Build();
+        }
+
+        public ObjectGraphType<T> Build()
+        {
+            var o = new ObjectGraphType<T>();
+            foreach (var item in _fields)
+            {
+                o.AddField(item.Value);
+            }
+            return o;
+        }
+
+        private EventStreamFieldType GetOrCreate(string name)
+        {
+            return _fields.ContainsKey(name) ? _fields[name] : (_fields[name] = new EventStreamFieldType() { Name = name, Type = typeof(ObjectGraphType<T>) });
+        }
+    }
+
+    public interface IBuildGraphQLType
+    {
+
+        IGraphType Build();
+    }
+
+
+    public class FieldBuilder
+    {
+        private readonly EventStreamFieldType _field;
+
+        public FieldBuilder(EventStreamFieldType field)
+        {
+            _field = field ?? throw new ArgumentNullException(nameof(field));
+        }
+
+
+        public FieldBuilder Description(string description)
+        {
+            _field.Description = description;
+            return this;
+        }
+
+        public FieldBuilder DefaultValue(object obj)
+        {
+            _field.DefaultValue = obj;
+            return this;
+        }
+
+
+
+    }
+
+}

--- a/GraphQL.AspNetCore.Data/GraphQl.AspNetCore.Data.csproj
+++ b/GraphQL.AspNetCore.Data/GraphQl.AspNetCore.Data.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GraphQL" Version="2.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0-preview6.19304.10" />
   </ItemGroup>
 

--- a/GraphQL.AspNetCore.Data/GraphQlContext.cs
+++ b/GraphQL.AspNetCore.Data/GraphQlContext.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace GraphQL.AspNetCore.Data
+{
+    public class GraphQlContext
+    {
+
+        public GraphQlContext(DbContext dbContext)
+                : this(dbContext.Model)
+        {
+
+        }
+
+
+        public GraphQlContext(IModel model)
+        {
+            Model = model;
+        }
+
+        public GraphQlContext(DbContextOptions dbContextOptions)
+        {
+            //dbContextOptions.FindExtension
+        }
+
+        public IModel Model { get; }
+
+        protected virtual void OnGraphCreating(GraphBuilder graphlBuilder)
+        {
+
+
+            
+
+
+
+
+
+
+        }
+
+        public void Build()
+        {
+
+
+
+
+
+
+
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    }
+
+
+
+
+
+
+
+}

--- a/GraphQL.AspNetCore.Data/GraphQlDataContext.cs
+++ b/GraphQL.AspNetCore.Data/GraphQlDataContext.cs
@@ -2,7 +2,7 @@
 
 namespace GraphQL.AspNetCore.Data
 {
-    public abstract class GraphQlDbContext : DbContext
+    public class GraphQlDbContext : DbContext
     {
 
         protected virtual void OnGraphCreating(GraphBuilder graphlBuilder)
@@ -10,4 +10,5 @@ namespace GraphQL.AspNetCore.Data
 
         }
     }
+
 }

--- a/GraphQlDemo.sln
+++ b/GraphQlDemo.sln
@@ -33,7 +33,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".shared", ".shared", "{3D80
 		global.json = global.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQl.AspNetCore.Data", "GraphQL.AspNetCore.Data\GraphQl.AspNetCore.Data.csproj", "{7A50E63F-3729-4BFB-8F04-2E652BB719A6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GraphQl.AspNetCore.Data", "GraphQL.AspNetCore.Data\GraphQl.AspNetCore.Data.csproj", "{7A50E63F-3729-4BFB-8F04-2E652BB719A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQl.AspNetCore.Data.Test", "test\GraphQl.AspNetCore.Data.Test\GraphQl.AspNetCore.Data.Test.csproj", "{400EDCFC-BC43-46EA-870D-E17177DFEEDF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,10 @@ Global
 		{7A50E63F-3729-4BFB-8F04-2E652BB719A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A50E63F-3729-4BFB-8F04-2E652BB719A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A50E63F-3729-4BFB-8F04-2E652BB719A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{400EDCFC-BC43-46EA-870D-E17177DFEEDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{400EDCFC-BC43-46EA-870D-E17177DFEEDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{400EDCFC-BC43-46EA-870D-E17177DFEEDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{400EDCFC-BC43-46EA-870D-E17177DFEEDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GraphQlDemo/Data/ApplicationDBContext.cs
+++ b/GraphQlDemo/Data/ApplicationDBContext.cs
@@ -30,4 +30,9 @@ namespace GraphQlDemo.Data
 
         }
     }
+
+
+
+  
+
 }

--- a/GraphQlDemo/GraphQlDemo.csproj
+++ b/GraphQlDemo/GraphQlDemo.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="GraphQL" Version="2.4.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview3-19153-02" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0-preview6.19304.10" />
+    <!--<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0-preview6.19304.10" />-->
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />

--- a/test/GraphQl.AspNetCore.Data.Test/GraphQl.AspNetCore.Data.Test.csproj
+++ b/test/GraphQl.AspNetCore.Data.Test/GraphQl.AspNetCore.Data.Test.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.0.0-preview6.19304.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GraphQL.AspNetCore.Data\GraphQl.AspNetCore.Data.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/GraphQl.AspNetCore.Data.Test/MyTestDbContext.cs
+++ b/test/GraphQl.AspNetCore.Data.Test/MyTestDbContext.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace GraphQl.AspNetCore.Data.Test
+{
+    public class MyTestDbContext : DbContext
+    {
+        public MyTestDbContext(DbContextOptions options) : base(options)
+        {
+        }
+
+        public MyTestDbContext()
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<MyClass>().HasKey(e => e.Id);
+            modelBuilder.Entity<MyClass>().Property(e => e.AnyProperty);
+
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            base.OnConfiguring(optionsBuilder);
+            optionsBuilder.UseInMemoryDatabase("InMemoryDatabase");
+        }
+
+    }
+}

--- a/test/GraphQl.AspNetCore.Data.Test/UnitTest1.cs
+++ b/test/GraphQl.AspNetCore.Data.Test/UnitTest1.cs
@@ -1,0 +1,61 @@
+using GraphQL.AspNetCore.Data;
+using System.Linq;
+using Xunit;
+
+namespace GraphQl.AspNetCore.Data.Test
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void GraphQLTypeBuilderTest()
+        {
+            var applicationDbContext = new MyTestDbContext();
+
+            var graphTypeForMyClass = GraphQLTypeBuilder.CreateFor<MyClass>()
+                  .FieldsFrom(applicationDbContext.Model)
+                  // Additional configuration:
+                  .Field(myClass => myClass.AnyProperty, with => with.Description("Description"))
+                  .Field(myClass => myClass.Id, with => with.DefaultValue("Default"))
+                  .Build();
+
+            Assert.True(graphTypeForMyClass.Fields.ToArray().Length == 2);
+        }
+
+        [Fact]
+        public void GraphBuilderTest()
+        {
+            var applicationDbContext = new MyTestDbContext();
+
+            var allGraphTypes = new GraphBuilder(applicationDbContext.Model)
+                .Define<MyClass>()
+                .Define<OtherClass>(o => o
+                    .Field(otherClass => otherClass.Test, with => with.Description("test"))
+                    .Field(otherClass => otherClass.Id, with => with.Description("test").DefaultValue("7")))
+                .BuildGraphTypes();
+
+            Assert.True(allGraphTypes.Count == 2);
+        }
+    }
+
+
+    public class MyClass
+    {
+
+        public int Id { get; set; }
+
+        public string AnyProperty { get; set; }
+
+    }
+
+
+    public class OtherClass
+    {
+
+        public int Id { get; set; }
+
+        public string Test { get; set; }
+        
+        public string Abc { get; set; }
+
+    }
+}


### PR DESCRIPTION
This is a draft of how the EF Core model could be used to build the foundation of the GraphQL types.
Not thought through in all details but I hope it is useful and leads to new ideas.